### PR TITLE
docs: clarify local secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Options:
   -x, --secret-provider <SECRET_PROVIDER>
           The secret provider to use: aws, vault or local. For local secret, this value should be the path to the file that holds the secret
   -n, --secret-name <SECRET_NAME>
-          The secret id to use
+          The secret id to use. For `local`, the name of the file holding the secret.
   -d, --effective-date-day <EFFECTIVE_DATE_DAY>
           The effective day (YYYY/MM/DD) for the Validation List (only for version 2)
   -t, --effective-date-time <EFFECTIVE_DATE_TIME>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated README to clarify usage of `--secret-name` option for the `sign` command
  - Added explanation about specifying file name when using `local` secret provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->